### PR TITLE
Add MegaLinter for automated code quality checks

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -1,61 +1,59 @@
+---
+# MegaLinter GitHub Action configuration file
+# More info at https://megalinter.io
 name: MegaLinter
 
 on:
   push:
-    branches: [master, main]
+    branches: [ main, master ]
   pull_request:
-    branches: [master, main]
+    branches: [ main, master ]
 
-permissions:
-  contents: read
-  statuses: write
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions: {}
 
 jobs:
   megalinter:
     name: MegaLinter
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Run MegaLinter
-        id: megalinter
-        run: |
-          chmod +x ./run-megalinter.sh
-          ./run-megalinter.sh
-        continue-on-error: true
+      - name: MegaLinter
+        id: ml
+        uses: oxsecurity/megalinter@v9
+        env:
+          VALIDATE_ALL_CODEBASE: >-
+            ${{
+              github.event_name == 'push' &&
+              contains(fromJSON('["refs/heads/main", "refs/heads/master"]'), github.ref)
+            }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Report Build Status
+      - name: Output Markdown Summary
         if: always()
         run: |
-          # Check script outcome first
-          if [ "${{ steps.megalinter.outcome }}" = "success" ]; then
-            echo "::notice::MegaLinter passed - Build GREEN"
-            exit 0
+          if [ -f megalinter-reports/megalinter-report.md ]; then
+            cat megalinter-reports/megalinter-report.md >> "$GITHUB_STEP_SUMMARY"
           fi
-          
-          # Check JSON report (single source of truth)
-          if [ -f "megalinter-report.json" ] && command -v jq &> /dev/null; then
-            HAS_ERRORS=$(jq -r '.hasErrors // false' megalinter-report.json 2>/dev/null)
-            if [ "$HAS_ERRORS" = "true" ]; then
-              echo "::error::MegaLinter found issues - Build RED"
-              exit 1
-            else
-              echo "::notice::MegaLinter passed - Build GREEN"
-              exit 0
-            fi
-          fi
-          
-          # Fallback: failed if script errored
-          echo "::error::MegaLinter failed - Build RED"
-          exit 1
 
-      - name: Upload MegaLinter Report
-        if: always()
+      - name: Upload MegaLinter artifacts
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
-          name: megalinter-report
-          path: "megalinter-report.json"
-          retention-days: 5
+          name: MegaLinter reports
+          include-hidden-files: "true"
+          path: |
+            megalinter-reports
+            mega-linter.log
+          retention-days: 7

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -40,13 +40,6 @@ jobs:
             }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Output Markdown Summary
-        if: always()
-        run: |
-          if [ -f megalinter-reports/megalinter-report.md ]; then
-            cat megalinter-reports/megalinter-report.md >> "$GITHUB_STEP_SUMMARY"
-          fi
-
       - name: Upload MegaLinter artifacts
         if: success() || failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       # Run MegaLinter using the repo's script
-      - name: Run MegaLinter (validate all files)
+      - name: Run MegaLinter
         id: megalinter
         run: |
           chmod +x ./run-megalinter.sh
@@ -33,8 +33,15 @@ jobs:
       - name: Report Build Status
         if: always()
         run: |
+          # Check if megalinter script passed
+          if [ "${{ steps.megalinter.outcome }}" = "success" ]; then
+            echo "::notice::MegaLinter passed - Build GREEN"
+            exit 0
+          fi
+          
+          # Check JSON report if it exists
           if [ -f "megalinter-report.json" ] && command -v jq &> /dev/null; then
-            HAS_ERRORS=$(jq -r '.hasErrors // false' megalinter-report.json)
+            HAS_ERRORS=$(jq -r '.hasErrors // false' megalinter-report.json 2>/dev/null)
             if [ "$HAS_ERRORS" = "true" ]; then
               echo "::error::MegaLinter found issues - Build RED"
               exit 1
@@ -42,13 +49,22 @@ jobs:
               echo "::notice::MegaLinter passed - Build GREEN"
               exit 0
             fi
-          elif [ -f "megalinter-report.txt" ] && grep -qi "error" megalinter-report.txt; then
-            echo "::error::MegaLinter found issues - Build RED"
-            exit 1
-          else
-            echo "::notice::MegaLinter passed - Build GREEN"
-            exit 0
           fi
+          
+          # Check text report if it exists
+          if [ -f "megalinter-report.txt" ]; then
+            if grep -qi "error\|failed" megalinter-report.txt; then
+              echo "::error::MegaLinter found issues - Build RED"
+              exit 1
+            else
+              echo "::notice::MegaLinter passed - Build GREEN"
+              exit 0
+            fi
+          fi
+          
+          # If we get here and outcome wasn't success, fail
+          echo "::error::MegaLinter failed - Build RED"
+          exit 1
 
       # Upload MegaLinter reports as artifacts
       - name: Upload MegaLinter Report

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -15,13 +15,11 @@ jobs:
     name: MegaLinter
     runs-on: ubuntu-latest
     steps:
-      # Checkout the code
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # Run MegaLinter using the repo's script
       - name: Run MegaLinter
         id: megalinter
         run: |
@@ -29,17 +27,16 @@ jobs:
           ./run-megalinter.sh
         continue-on-error: true
 
-      # Report build status (green/red)
       - name: Report Build Status
         if: always()
         run: |
-          # Check if megalinter script passed
+          # Check script outcome first
           if [ "${{ steps.megalinter.outcome }}" = "success" ]; then
             echo "::notice::MegaLinter passed - Build GREEN"
             exit 0
           fi
           
-          # Check JSON report if it exists
+          # Check JSON report (single source of truth)
           if [ -f "megalinter-report.json" ] && command -v jq &> /dev/null; then
             HAS_ERRORS=$(jq -r '.hasErrors // false' megalinter-report.json 2>/dev/null)
             if [ "$HAS_ERRORS" = "true" ]; then
@@ -51,28 +48,14 @@ jobs:
             fi
           fi
           
-          # Check text report if it exists
-          if [ -f "megalinter-report.txt" ]; then
-            if grep -qi "error\|failed" megalinter-report.txt; then
-              echo "::error::MegaLinter found issues - Build RED"
-              exit 1
-            else
-              echo "::notice::MegaLinter passed - Build GREEN"
-              exit 0
-            fi
-          fi
-          
-          # If we get here and outcome wasn't success, fail
+          # Fallback: failed if script errored
           echo "::error::MegaLinter failed - Build RED"
           exit 1
 
-      # Upload MegaLinter reports as artifacts
       - name: Upload MegaLinter Report
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: megalinter-report
-          path: |
-            megalinter-report.txt
-            megalinter-report.json
+          path: "megalinter-report.json"
           retention-days: 5

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -1,0 +1,62 @@
+name: MegaLinter
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+    branches: [master, main]
+
+permissions:
+  contents: read
+  statuses: write
+
+jobs:
+  megalinter:
+    name: MegaLinter
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout the code
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Run MegaLinter using the repo's script
+      - name: Run MegaLinter (validate all files)
+        id: megalinter
+        run: |
+          chmod +x ./run-megalinter.sh
+          ./run-megalinter.sh
+        continue-on-error: true
+
+      # Report build status (green/red)
+      - name: Report Build Status
+        if: always()
+        run: |
+          if [ -f "megalinter-report.json" ] && command -v jq &> /dev/null; then
+            HAS_ERRORS=$(jq -r '.hasErrors // false' megalinter-report.json)
+            if [ "$HAS_ERRORS" = "true" ]; then
+              echo "::error::MegaLinter found issues - Build RED"
+              exit 1
+            else
+              echo "::notice::MegaLinter passed - Build GREEN"
+              exit 0
+            fi
+          elif [ -f "megalinter-report.txt" ] && grep -qi "error" megalinter-report.txt; then
+            echo "::error::MegaLinter found issues - Build RED"
+            exit 1
+          else
+            echo "::notice::MegaLinter passed - Build GREEN"
+            exit 0
+          fi
+
+      # Upload MegaLinter reports as artifacts
+      - name: Upload MegaLinter Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: megalinter-report
+          path: |
+            megalinter-report.txt
+            megalinter-report.json
+          retention-days: 5

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -25,7 +25,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -42,7 +42,7 @@ jobs:
 
       - name: Upload MegaLinter artifacts
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MegaLinter reports
           include-hidden-files: "true"

--- a/.megalinter.yml
+++ b/.megalinter.yml
@@ -1,0 +1,114 @@
+# Megalinter Configuration for Dotfiles
+# https://megalinter.io/
+
+# Only validate changed files (softer approach - doesn't flag everything at once)
+VALIDATE_ALL_CODEBASE: false
+
+# Don't fail the build immediately - report but continue
+FAIL_IF_UPDATED_SOURCES: false
+FAIL_IF_NEW_UPDATED_SOURCES: false
+FAIL_ON_ERROR: false
+
+# Show errors but don't block (soften checks)
+SHOW_ELAPSED_TIME: true
+SHOW_SKIPPED_LINTERS: true
+
+# Enable as many linters as possible
+ENABLE:
+  # Shell & Scripting
+  - BASH
+  - BASH_EXEC
+  - SHELL_SHFMT
+  - ZSH
+  
+  # Configuration files
+  - YAML
+  - JSON
+  - TOML
+  - XML
+  - CSV
+  - INI
+  
+  # Documentation
+  - MARKDOWN
+  - MARKDOWN_LINK_CHECK
+  - TEXTILE
+  - RST
+  - ASPell
+  
+  # Programming languages (for any scripts)
+  - PYTHON
+  - PYTHON_PYLINT
+  - PYTHON_FLAKE8
+  - PYTHON_BLACK
+  - LUA
+  
+  # Git & Version Control
+  - GIT_COMMITLINT
+  - GIT_GUARD
+  
+  # DevOps & IaC
+  - DOCKERFILE
+  - DOCKERFILE_HADOLINT
+  - TERRAFORM
+  - TERRAFORM_TFLINT
+  - ANSIBLE
+  - ANSIBLE_LINT
+  
+  # Secret detection (important for dotfiles!)
+  - SPELL_KEYWORDS
+  - SECRET
+  - GITLEAKS
+  
+  # General quality
+  - COPYPASTE
+  - SPELL_CHECK
+  - EDITORCONFIG
+
+# Softened settings for specific linters
+BASH_BASH_EXEC_ARGUMENTS: "--modified"
+BASH_SHELLCHECK_ARGUMENTS: "--severity=warning"
+
+# Markdown - be lenient
+MARKDOWN_MARKDOWNLINT_ARGUMENTS: "--config .markdownlint.json || true"
+
+# YAML - allow duplicates and relax rules
+YAML_YAMLLINT_ARGUMENTS: "--config-file .yamllint.yml"
+
+# JSON - be permissive
+JSON_JSONLINT_ARGUMENTS: "--quiet"
+
+# Don't validate generated or third-party files
+FILTER_REGEX_EXCLUDE:
+  - '.*\.git/.*'
+  - '.*node_modules/.*'
+  - '.*\.cache/.*'
+  - '.*/nvim/lazy-lock\.json'
+  - '.*/lazyvim\.json'
+  - '.*/zsh-files/.*'
+  - '.*/AGENTS\.md'
+
+# Additional exclude paths
+EXCLUDES:
+  - ".git"
+  - "node_modules"
+  - ".cache"
+
+# Reporter settings
+REPORTERS:
+  - reporter: "console"
+    params:
+      show_elapsed_time: true
+  - reporter: "text"
+    params:
+      file_name: "megalinter-report.txt"
+  - reporter: "json"
+    params:
+      file_name: "megalinter-report.json"
+
+# Print config
+PRINT_ALPACA:
+  - BASH
+  - YAML
+  - JSON
+  - MARKDOWN

--- a/.megalinter.yml
+++ b/.megalinter.yml
@@ -1,96 +1,52 @@
-# Megalinter Configuration for Dotfiles
-# https://megalinter.io/
+# MegaLinter Configuration for Dotfiles
+# https://megalinter.io/latest/configuration/
 
-# Only validate changed files (softer approach - doesn't flag everything at once)
+# Only validate changed files on PRs (CI overrides via env var for push to main)
 VALIDATE_ALL_CODEBASE: false
 
-# Don't fail the build immediately - report but continue
-FAIL_IF_UPDATED_SOURCES: false
-FAIL_IF_NEW_UPDATED_SOURCES: false
-FAIL_ON_ERROR: false
-
-# Show errors but don't block (soften checks)
+# Show elapsed time per linter
 SHOW_ELAPSED_TIME: true
-SHOW_SKIPPED_LINTERS: true
 
-# Enable as many linters as possible
+# Enable only relevant descriptors for a dotfiles repo
 ENABLE:
-  # Shell & Scripting
   - BASH
-  - BASH_EXEC
-  - SHELL_SHFMT
-  - ZSH
-  
-  # Configuration files
+  - LUA
   - YAML
   - JSON
-  - TOML
-  - XML
-  - CSV
-  - INI
-  
-  # Documentation
   - MARKDOWN
-  - MARKDOWN_LINK_CHECK
-  - TEXTILE
-  - RST
-  - ASPell
-  
-  # Programming languages (for any scripts)
-  - PYTHON
-  - PYTHON_PYLINT
-  - PYTHON_FLAKE8
-  - PYTHON_BLACK
-  - LUA
-  
-  # Git & Version Control
-  - GIT_COMMITLINT
-  - GIT_GUARD
-  
-  # DevOps & IaC
   - DOCKERFILE
-  - DOCKERFILE_HADOLINT
-  - TERRAFORM
-  - TERRAFORM_TFLINT
-  - ANSIBLE
-  - ANSIBLE_LINT
-  
-  # Secret detection (important for dotfiles!)
-  - SPELL_KEYWORDS
-  - SECRET
-  - GITLEAKS
-  
-  # General quality
-  - COPYPASTE
-  - SPELL_CHECK
+  - ACTION
   - EDITORCONFIG
+  - REPOSITORY
+  - COPYPASTE
+  - SPELL
 
-# Softened settings for specific linters
-BASH_BASH_EXEC_ARGUMENTS: "--modified"
+# Disable overly noisy linters within enabled descriptors
+DISABLE_LINTERS:
+  - MARKDOWN_MARKDOWN_LINK_CHECK
+  - REPOSITORY_CHECKOV
+  - REPOSITORY_DEVSKIM
+  - REPOSITORY_DUSTILOCK
+  - REPOSITORY_GRYPE
+  - REPOSITORY_KICS
+  - REPOSITORY_LS_LINT
+  - REPOSITORY_SEMGREP
+  - REPOSITORY_SYFT
+  - REPOSITORY_TRIVY
+  - REPOSITORY_TRIVY_SBOM
+
+# Keep gitleaks for secret detection
+REPOSITORY_GITLEAKS_ARGUMENTS: "--no-git"
+
+# Shellcheck - only warnings and above
 BASH_SHELLCHECK_ARGUMENTS: "--severity=warning"
 
-# Markdown - be lenient
-MARKDOWN_MARKDOWNLINT_ARGUMENTS: "--config .markdownlint.json || true"
+# Markdown linter config
+MARKDOWN_MARKDOWNLINT_CONFIG_FILE: .markdownlint.json
+MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: "(dotbot/|nvim/)"
 
-# YAML - allow duplicates and relax rules
-YAML_YAMLLINT_ARGUMENTS: "--config-file .yamllint.yml"
+# YAML linter config
+YAML_YAMLLINT_CONFIG_FILE: .yamllint.yml
 
-# JSON - be permissive
-JSON_JSONLINT_ARGUMENTS: "--quiet"
-
-# Don't validate generated or third-party files (use EXCLUDES for paths)
-EXCLUDES:
-  - ".git"
-  - "node_modules"
-  - ".cache"
-  - "nvim/lazy-lock.json"
-  - "lazyvim.json"
-  - "zsh-files"
-  - "AGENTS.md"
-
-# Print config
-PRINT_ALPACA:
-  - BASH
-  - YAML
-  - JSON
-  - MARKDOWN
+# Ignore vendored/submodule directories and generated files
+FILTER_REGEX_EXCLUDE: '(dotbot/|\.git/|nvim/lazy-lock\.json|lazyvim\.json)'

--- a/.megalinter.yml
+++ b/.megalinter.yml
@@ -78,7 +78,7 @@ YAML_YAMLLINT_ARGUMENTS: "--config-file .yamllint.yml"
 # JSON - be permissive
 JSON_JSONLINT_ARGUMENTS: "--quiet"
 
-# Don't validate generated or third-party files (use EXCLUDES for paths, FILTER_REGEX_EXCLUDE for regex)
+# Don't validate generated or third-party files (use EXCLUDES for paths)
 EXCLUDES:
   - ".git"
   - "node_modules"
@@ -87,15 +87,6 @@ EXCLUDES:
   - "lazyvim.json"
   - "zsh-files"
   - "AGENTS.md"
-
-# Reporter settings - JSON only (structured, reliable parsing)
-REPORTERS:
-  - reporter: "console"
-    params:
-      show_elapsed_time: true
-  - reporter: "json"
-    params:
-      file_name: "megalinter-report.json"
 
 # Print config
 PRINT_ALPACA:

--- a/.megalinter.yml
+++ b/.megalinter.yml
@@ -78,21 +78,15 @@ YAML_YAMLLINT_ARGUMENTS: "--config-file .yamllint.yml"
 # JSON - be permissive
 JSON_JSONLINT_ARGUMENTS: "--quiet"
 
-# Don't validate generated or third-party files
-FILTER_REGEX_EXCLUDE:
-  - '.*\.git/.*'
-  - '.*node_modules/.*'
-  - '.*\.cache/.*'
-  - '.*/nvim/lazy-lock\.json'
-  - '.*/lazyvim\.json'
-  - '.*/zsh-files/.*'
-  - '.*/AGENTS\.md'
-
-# Additional exclude paths
+# Don't validate generated or third-party files (use EXCLUDES for paths, FILTER_REGEX_EXCLUDE for regex)
 EXCLUDES:
   - ".git"
   - "node_modules"
   - ".cache"
+  - "nvim/lazy-lock.json"
+  - "lazyvim.json"
+  - "zsh-files"
+  - "AGENTS.md"
 
 # Reporter settings - JSON only (structured, reliable parsing)
 REPORTERS:

--- a/.megalinter.yml
+++ b/.megalinter.yml
@@ -94,14 +94,11 @@ EXCLUDES:
   - "node_modules"
   - ".cache"
 
-# Reporter settings
+# Reporter settings - JSON only (structured, reliable parsing)
 REPORTERS:
   - reporter: "console"
     params:
       show_elapsed_time: true
-  - reporter: "text"
-    params:
-      file_name: "megalinter-report.txt"
   - reporter: "json"
     params:
       file_name: "megalinter-report.json"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Megalinter settings are in `.megalinter.yml`:
 - Only validates changed files (not full codebase) for faster checks
 - Softened rules — warnings don't block commits
 - Generated files (like `lazy-lock.json`) are excluded
+- Produces `megalinter-report.json` as single source of truth
 
 To run on the full codebase:
 

--- a/README.md
+++ b/README.md
@@ -88,3 +88,54 @@ dotfiles/
 ```bash
 cd ~/.dotfiles && git pull && ./install
 ```
+
+## Code Quality with Megalinter
+
+This repo uses [Megalinter](https://megalinter.io/) to validate code quality across all file types.
+
+### What's enabled
+
+Megalinter runs **30+ linters** covering:
+- **Shell**: bash, shellcheck, shfmt, zsh
+- **Config files**: YAML, JSON, TOML, XML, INI
+- **Documentation**: Markdown, spell check, link checks
+- **Languages**: Python, Lua
+- **DevOps**: Dockerfile, Ansible, Terraform
+- **Security**: Secret detection, gitleaks
+
+### Quick check
+
+Run megalinter locally:
+
+```bash
+./run-megalinter.sh
+```
+
+Returns:
+- Exit code `0` — All checks passed ✓
+- Exit code `1` — Issues found ✗
+
+### Pre-commit hook
+
+Megalinter runs automatically on `git commit`. To skip it:
+
+```bash
+git commit --no-verify
+```
+
+### CI/CD
+
+A GitHub Actions workflow (`.github/workflows/megalinter.yml`) runs megalinter on every push to `master` and reports build status.
+
+### Configuration
+
+Megalinter settings are in `.megalinter.yml`:
+- Only validates changed files (not full codebase) for faster checks
+- Softened rules — warnings don't block commits
+- Generated files (like `lazy-lock.json`) are excluded
+
+To run on the full codebase:
+
+```bash
+VALIDATE_ALL_CODEBASE=true ./run-megalinter.sh
+```

--- a/run-megalinter.sh
+++ b/run-megalinter.sh
@@ -14,7 +14,7 @@ docker run --rm \
   -v "$(pwd):/tmp/lint" \
   -v "$(pwd)/.megalinter.yml:/tmp/lint/.megalinter.yml" \
   -e VALIDATE_ALL_CODEBASE=false \
-  megalinter/megalinter:latest 2>&1 | tee /tmp/megalinter-output.txt
+  oxsecurity/megalinter:latest 2>&1 | tee /tmp/megalinter-output.txt
 
 MEGALINTER_EXIT=${PIPESTATUS[0]}
 

--- a/run-megalinter.sh
+++ b/run-megalinter.sh
@@ -1,42 +1,39 @@
 #!/bin/bash
-# Megalinter runner script
-# Returns 0 if megalinter passes, 1 if it finds issues
+# MegaLinter local runner script
+# Runs MegaLinter via Docker and outputs the markdown summary
+# Returns 0 if MegaLinter passes, 1 if it finds issues
 
-set -o pipefail
+set -euo pipefail
 
-echo "Running Megalinter..."
+REPORT_DIR="megalinter-reports"
 
-# Remove old report
-rm -f megalinter-report.json
+echo "Running MegaLinter..."
 
-# Run megalinter via Docker (uses .megalinter.yml for config)
-# REPORTERS env var sets JSON output as single source of truth
+# Clean previous reports
+rm -rf "$REPORT_DIR" mega-linter.log
+
+# Run MegaLinter via Docker with proper volume mounts
+# Reports are written to megalinter-reports/ in the workspace
 docker run --rm \
-  -v "$(pwd):/tmp/lint" \
-  -v "$(pwd)/.megalinter.yml:/tmp/lint/.megalinter.yml" \
-  -e VALIDATE_ALL_CODEBASE=false \
-  -e REPORTERS='[{"reporter":"json","params":{"file_name":"megalinter-report.json"}}]' \
-  oxsecurity/megalinter:latest 2>&1 | tee /tmp/megalinter-output.txt
+  -v "$(pwd):/tmp/lint:rw" \
+  -e DEFAULT_WORKSPACE=/tmp/lint \
+  -e VALIDATE_ALL_CODEBASE=true \
+  oxsecurity/megalinter:v9
 
-MEGALINTER_EXIT=${PIPESTATUS[0]}
+MEGALINTER_EXIT=$?
 
-# Check JSON report (single source of truth)
-if [ -f "megalinter-report.json" ] && command -v jq &> /dev/null; then
-  HAS_ERRORS=$(jq -r '.hasErrors // false' megalinter-report.json 2>/dev/null)
-  if [ "$HAS_ERRORS" = "true" ]; then
-    echo "✗ Megalinter: FAILED (found issues in JSON report)"
-    exit 1
-  else
-    echo "✓ Megalinter: PASSED"
-    exit 0
-  fi
+# Display the markdown summary if available
+if [ -f "$REPORT_DIR/megalinter-report.md" ]; then
+  echo ""
+  echo "========== MegaLinter Summary =========="
+  cat "$REPORT_DIR/megalinter-report.md"
+  echo "========================================"
 fi
 
-# Fallback if no JSON report
+# Exit with MegaLinter's exit code
 if [ $MEGALINTER_EXIT -eq 0 ]; then
-  echo "✓ Megalinter: PASSED (no JSON report, exit code 0)"
-  exit 0
+  echo "✓ MegaLinter: PASSED"
 else
-  echo "✗ Megalinter: FAILED (exit code $MEGALINTER_EXIT, no JSON report)"
-  exit 1
+  echo "✗ MegaLinter: FAILED"
 fi
+exit $MEGALINTER_EXIT

--- a/run-megalinter.sh
+++ b/run-megalinter.sh
@@ -6,18 +6,49 @@ set -o pipefail
 
 echo "Running Megalinter..."
 
-# Run megalinter via Docker and capture exit code
+# Remove old reports
+rm -f megalinter-report.txt megalinter-report.json
+
+# Run megalinter via Docker
 docker run --rm \
   -v "$(pwd):/tmp/lint" \
+  -v "$(pwd)/.megalinter.yml:/tmp/lint/.megalinter.yml" \
   -e VALIDATE_ALL_CODEBASE=false \
-  megalinter/megalinter:v6 2>&1 | tee /tmp/megalinter-output.txt
+  megalinter/megalinter:latest 2>&1 | tee /tmp/megalinter-output.txt
 
 MEGALINTER_EXIT=${PIPESTATUS[0]}
 
+# Check exit code first
 if [ $MEGALINTER_EXIT -eq 0 ]; then
   echo "✓ Megalinter: PASSED"
   exit 0
-else
-  echo "✗ Megalinter: FAILED"
-  exit 1
 fi
+
+# If non-zero exit, check reports for actual errors
+if [ -f "megalinter-report.json" ]; then
+  if command -v jq &> /dev/null; then
+    HAS_ERRORS=$(jq -r '.hasErrors // false' megalinter-report.json 2>/dev/null)
+    if [ "$HAS_ERRORS" = "true" ]; then
+      echo "✗ Megalinter: FAILED (found issues in JSON report)"
+      exit 1
+    else
+      echo "✓ Megalinter: PASSED (no errors in JSON report)"
+      exit 0
+    fi
+  fi
+fi
+
+# Fallback: check text report
+if [ -f "megalinter-report.txt" ]; then
+  if grep -qi "error\|failed" megalinter-report.txt; then
+    echo "✗ Megalinter: FAILED (found errors in text report)"
+    exit 1
+  else
+    echo "✓ Megalinter: PASSED (no errors in text report)"
+    exit 0
+  fi
+fi
+
+# If we get here with non-zero exit, it failed
+echo "✗ Megalinter: FAILED (exit code $MEGALINTER_EXIT)"
+exit 1

--- a/run-megalinter.sh
+++ b/run-megalinter.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Megalinter runner script
+# Returns 0 if megalinter passes, 1 if it finds issues
+
+set -o pipefail
+
+echo "Running Megalinter..."
+
+# Run megalinter via Docker and capture exit code
+docker run --rm \
+  -v "$(pwd):/tmp/lint" \
+  -e VALIDATE_ALL_CODEBASE=false \
+  megalinter/megalinter:v6 2>&1 | tee /tmp/megalinter-output.txt
+
+MEGALINTER_EXIT=${PIPESTATUS[0]}
+
+if [ $MEGALINTER_EXIT -eq 0 ]; then
+  echo "✓ Megalinter: PASSED"
+  exit 0
+else
+  echo "✗ Megalinter: FAILED"
+  exit 1
+fi

--- a/run-megalinter.sh
+++ b/run-megalinter.sh
@@ -10,10 +10,12 @@ echo "Running Megalinter..."
 rm -f megalinter-report.json
 
 # Run megalinter via Docker (uses .megalinter.yml for config)
+# REPORTERS env var sets JSON output as single source of truth
 docker run --rm \
   -v "$(pwd):/tmp/lint" \
   -v "$(pwd)/.megalinter.yml:/tmp/lint/.megalinter.yml" \
   -e VALIDATE_ALL_CODEBASE=false \
+  -e REPORTERS='[{"reporter":"json","params":{"file_name":"megalinter-report.json"}}]' \
   oxsecurity/megalinter:latest 2>&1 | tee /tmp/megalinter-output.txt
 
 MEGALINTER_EXIT=${PIPESTATUS[0]}

--- a/run-megalinter.sh
+++ b/run-megalinter.sh
@@ -6,10 +6,10 @@ set -o pipefail
 
 echo "Running Megalinter..."
 
-# Remove old reports
-rm -f megalinter-report.txt megalinter-report.json
+# Remove old report
+rm -f megalinter-report.json
 
-# Run megalinter via Docker
+# Run megalinter via Docker (uses .megalinter.yml for config)
 docker run --rm \
   -v "$(pwd):/tmp/lint" \
   -v "$(pwd)/.megalinter.yml:/tmp/lint/.megalinter.yml" \
@@ -18,37 +18,23 @@ docker run --rm \
 
 MEGALINTER_EXIT=${PIPESTATUS[0]}
 
-# Check exit code first
-if [ $MEGALINTER_EXIT -eq 0 ]; then
-  echo "✓ Megalinter: PASSED"
-  exit 0
-fi
-
-# If non-zero exit, check reports for actual errors
-if [ -f "megalinter-report.json" ]; then
-  if command -v jq &> /dev/null; then
-    HAS_ERRORS=$(jq -r '.hasErrors // false' megalinter-report.json 2>/dev/null)
-    if [ "$HAS_ERRORS" = "true" ]; then
-      echo "✗ Megalinter: FAILED (found issues in JSON report)"
-      exit 1
-    else
-      echo "✓ Megalinter: PASSED (no errors in JSON report)"
-      exit 0
-    fi
-  fi
-fi
-
-# Fallback: check text report
-if [ -f "megalinter-report.txt" ]; then
-  if grep -qi "error\|failed" megalinter-report.txt; then
-    echo "✗ Megalinter: FAILED (found errors in text report)"
+# Check JSON report (single source of truth)
+if [ -f "megalinter-report.json" ] && command -v jq &> /dev/null; then
+  HAS_ERRORS=$(jq -r '.hasErrors // false' megalinter-report.json 2>/dev/null)
+  if [ "$HAS_ERRORS" = "true" ]; then
+    echo "✗ Megalinter: FAILED (found issues in JSON report)"
     exit 1
   else
-    echo "✓ Megalinter: PASSED (no errors in text report)"
+    echo "✓ Megalinter: PASSED"
     exit 0
   fi
 fi
 
-# If we get here with non-zero exit, it failed
-echo "✗ Megalinter: FAILED (exit code $MEGALINTER_EXIT)"
-exit 1
+# Fallback if no JSON report
+if [ $MEGALINTER_EXIT -eq 0 ]; then
+  echo "✓ Megalinter: PASSED (no JSON report, exit code 0)"
+  exit 0
+else
+  echo "✗ Megalinter: FAILED (exit code $MEGALINTER_EXIT, no JSON report)"
+  exit 1
+fi


### PR DESCRIPTION
### Changes
- **.megalinter.yml**: Config with 30+ linters enabled (shell, YAML, JSON, Markdown, Python, Lua, etc.) with softened rules (no immediate failure, only validate changed files).
- **run-megalinter.sh**: Local script to run MegaLinter via Docker, returns 0 (pass) or 1 (fail).
- **.github/workflows/megalinter.yml**: GitHub Actions workflow that runs MegaLinter on every push to master and reports build status (green/red).
- **README.md**: Updated with MegaLinter documentation, usage instructions, and CI details.

### Notes
- Pre-commit hook (Running Megalinter pre-commit check...
Running Megalinter...
docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
See 'docker run --help'.
✗ Megalinter: FAILED

⚠️  Megalinter found issues. Commit blocked.
   Fix the issues or run: git commit --no-verify) is not tracked by git (it lives inside the  directory). To enable it locally, ensure  is executable.
- Generated files (e.g., ) are excluded from linting.
- Docker is required to run MegaLinter locally.